### PR TITLE
add support for g:fzf_action

### DIFF
--- a/autoload/fern/mapping/fzf.vim
+++ b/autoload/fern/mapping/fzf.vim
@@ -103,19 +103,22 @@ function! s:make_sink(root_path, common_sink) abort
       return
     endif
     let key = remove(a:lines, 0)
-    let rel_paths = map(a:lines, function('s:nomalize_rel'))
+    let rel_paths = a:lines
+    call map(rel_paths, {->s:nomalize_rel(v:val)})
     let ex_dir_sink =  type(g:Fern_mapping_fzf_dir_sink) == v:t_func
     let ex_file_sink =  type(g:Fern_mapping_fzf_file_sink) == v:t_func
 
     if !ex_dir_sink && !ex_file_sink
-      let full_paths = map(rel_path, {->s:F.join(a:root_path, v:val)})
+      let full_paths = copy(rel_paths)
+      call map(full_paths, {->s:F.join(a:root_path, v:val)})
       call a:common_sink([key] + full_paths)
     else
       let dir_paths = [key]
       let file_paths = [key]
-      for relative_path in a:rel_paths
+      for relative_path in rel_paths
         let full_path = s:F.join(a:root_path, relative_path)
         let dict = {
+              \   'key': key,
               \   'root_path': a:root_path,
               \   'full_path': full_path,
               \   'relative_path': relative_path,
@@ -136,7 +139,7 @@ function! s:make_sink(root_path, common_sink) abort
           endif
         endif
       endfor
-      if ex_dir_sink
+      if !ex_dir_sink
         call a:common_sink(dir_paths)
       endif
       if !ex_file_sink

--- a/autoload/fern/mapping/fzf.vim
+++ b/autoload/fern/mapping/fzf.vim
@@ -76,7 +76,7 @@ function! s:fzf(helper, files, dirs) abort
         \   }
         \ )
   let opts['sink*'] = s:make_sink(root_path, opts['sink*'])
-  if type(g:Fern_mapping_fzf_customize_option) == v:t_func
+  if exists("*g:Fern_mapping_fzf_customize_option") || type(get(g:, "Fern_mapping_fzf_customize_option")) == v:t_func
     let opts = g:Fern_mapping_fzf_customize_option(opts)
   endif
   call fzf#run(
@@ -105,8 +105,8 @@ function! s:make_sink(root_path, common_sink) abort
     let key = remove(a:lines, 0)
     let rel_paths = a:lines
     call map(rel_paths, {->s:nomalize_rel(v:val)})
-    let ex_dir_sink =  type(g:Fern_mapping_fzf_dir_sink) == v:t_func
-    let ex_file_sink =  type(g:Fern_mapping_fzf_file_sink) == v:t_func
+    let ex_dir_sink = exists("*g:Fern_mapping_fzf_dir_sink") || type(get(g:, "Fern_mapping_fzf_dir_sink")) == v:t_func
+    let ex_file_sink = exists("*g:Fern_mapping_fzf_file_sink") || type(get(g:, "Fern_mapping_fzf_file_sink")) == v:t_func
 
     if !ex_dir_sink && !ex_file_sink
       let full_paths = copy(rel_paths)
@@ -163,9 +163,4 @@ let g:Fern_mapping_fzf_dir_sink = get(g:, 'Fern_mapping_fzf_dir_sink', 0)
 let g:Fern_mapping_fzf_file_sink = get(g:, 'Fern_mapping_fzf_file_sink', 0)
 
 " Deprecated
-if exists('g:fern#mapping#fzf#fzf_options')
-  echohl WarningMsg
-  echo "fern-mapping-fzf: warning: g:fern#mapping#fzf#fzf_options is deprecated. Please consider using Fern_mapping_fzf_customize_option instead."
-  echohl NONE
-endif
 let g:fern#mapping#fzf#fzf_options = get(g:, 'fern#mapping#fzf#fzf_options', {})

--- a/doc/fern-mapping-fzf.txt
+++ b/doc/fern-mapping-fzf.txt
@@ -83,6 +83,12 @@ Example: >
 *g:Fern_mapping_fzf_customize_option*
 	Set funcref that accepts one {spec-dict} argument and return dict.
 	This would be passed to |fzf#run|. See |fzf#run| for more information.
+Example: >
+	function! Fern_mapping_fzf_customize_option(spec)
+	    let a:spec.options .= ' --multi'
+	    return a:spec
+	endfunction
+  <
 
 *g:fern#mapping#fzf#fzf_options*
 	DEPRECATED: Please consider using |g:Fern_mapping_fzf_customize_option| instead.

--- a/doc/fern-mapping-fzf.txt
+++ b/doc/fern-mapping-fzf.txt
@@ -59,7 +59,7 @@ OPTIONS 				*fern-mapping-fzf-options*
 	  {dict}.is_dir		: |v:false|
 	  {dict}.root_path	: Path original fern executed.
 	Note: Censoring the drawer mode is not supported now, sorry.
-	Default: Run |:edit|
+	Default: Respects fzf default behavior. See |g:fzf_action|.
 Example: >
 	" Recipe for :FernReveal
 	function! s:reveal(dict) abort
@@ -76,9 +76,14 @@ Example: >
 				  directory. Useful for |:FernReveal|.
 	  {dict}.is_dir		: |v:true|
 	  {dict}.root_path	: Path original fern executed.
-	Default: Run |:Fern|
+	Default: Respects fzf default behavior. See |g:fzf_action|.
+
+*g:Fern_mapping_fzf_customize_option*
+	Set funcref that accepts one {spec-dict} argument and return dict.
+	This would be passed to |fzf#run|. See |fzf#run| for more information.
 
 *g:fern#mapping#fzf#fzf_options*
+	DEPRECATED: Please consider using |g:Fern_mapping_fzf_customize_option| instead.
 	This is extended to options that is going to be passed to |fzf#run|.
 	Default: `{}`
 

--- a/doc/fern-mapping-fzf.txt
+++ b/doc/fern-mapping-fzf.txt
@@ -53,6 +53,7 @@ OPTIONS 				*fern-mapping-fzf-options*
 
 *g:Fern_mapping_fzf_file_sink*
 	Set funcref that accepts one {dict} argument.
+	  {dict}.key		: The key used to finish fzf. e.g. `ctrl-v`
 	  {dict}.full_path	: Full path to the file.
 	  {dict}.relative_path	: Relative path from {dict}.root_path to the
 				  file. Useful for |:FernReveal|.
@@ -71,6 +72,7 @@ Example: >
 
 *g:Fern_mapping_fzf_dir_sink*
 	Set funcref that accepts one {dict} argument.
+	  {dict}.key		: The key used to finish fzf. e.g. `ctrl-v`
 	  {dict}.full_path	: Full path to the directory
 	  {dict}.relative_path	: Relative path from {dict}.root_path to the
 				  directory. Useful for |:FernReveal|.


### PR DESCRIPTION
- Resolves https://github.com/LumaKernel/fern-mapping-fzf.vim/issues/4
- Add support for `g:fzf_action`. When there is no custom user sink functions for this plugin, that will be used.
- Deprecate `g:fern#mapping#fzf#fzf_options` (minor option).
- Add option `g:Fern_mapping_fzf_customize_option` that should accept `fzf#run` spec dictionary and return.