### PR TITLE
Add some new options

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,32 @@ More details, see [`:help fern-mapping-fzf`](https://github.com/LumaKernel/fern-
 
 ![fern-mapping-fzf](https://user-images.githubusercontent.com/29811106/77903876-8e00ef00-72be-11ea-8d17-fa312cc2ab93.gif)
 
+## Sample settings
+
+### FZF multiple and mark on Fern
+
+```
+function! Fern_mapping_fzf_customize_option(spec)
+    let a:spec.options .= ' --multi'
+    return fzf#vim#with_preview(a:spec)
+endfunction
+
+function! Fern_mapping_fzf_before_all(dict)
+    if !len(a:dict.lines)
+        return
+    endif
+    return a:dict.fern_helper.async.update_marks([])
+endfunction
+
+function! s:reveal(dict)
+    execute "FernReveal -wait" a:dict.relative_path
+    execute "normal \<Plug>(fern-action-mark:set)"
+endfunction
+
+let g:Fern_mapping_fzf_file_sink = function('s:reveal')
+let g:Fern_mapping_fzf_dir_sink = function('s:reveal')
+```
+
 ## License
 
-[MIT](https://github.com/LumaKernel/fern-mapping-fzf.vim/blob/master/LICENSE) .
-
+[MIT](https://github.com/LumaKernel/fern-mapping-fzf.vim/blob/master/LICENSE)

--- a/autoload/fern/mapping/fzf.vim
+++ b/autoload/fern/mapping/fzf.vim
@@ -194,11 +194,6 @@ function! s:escape(str) abort
 endfunction
 
 let g:fern#mapping#fzf#disable_default_mappings = get(g:, 'fern#mapping#fzf#disable_default_mappings', 0)
-let g:Fern_mapping_fzf_before_all = get(g:, 'Fern_mapping_fzf_before_all', 0)
-let g:Fern_mapping_fzf_after_all = get(g:, 'Fern_mapping_fzf_after_all', 0)
-let g:Fern_mapping_fzf_customize_option = get(g:, 'Fern_mapping_fzf_customize_option', 0)
-let g:Fern_mapping_fzf_dir_sink = get(g:, 'Fern_mapping_fzf_dir_sink', 0)
-let g:Fern_mapping_fzf_file_sink = get(g:, 'Fern_mapping_fzf_file_sink', 0)
 
 " Deprecated
 let g:fern#mapping#fzf#fzf_options = get(g:, 'fern#mapping#fzf#fzf_options', {})

--- a/autoload/fern/mapping/fzf.vim
+++ b/autoload/fern/mapping/fzf.vim
@@ -75,7 +75,7 @@ function! s:fzf(helper, files, dirs) abort
         \     'dir': root_path,
         \   }
         \ )
-  let opts['sink*'] = s:make_sink(root_path, opts['sink*'])
+  let opts['sink*'] = s:make_sink(root_path, opts['sink*'], a:helper)
   if exists("*g:Fern_mapping_fzf_customize_option") || type(get(g:, "Fern_mapping_fzf_customize_option")) == v:t_func
     let opts = g:Fern_mapping_fzf_customize_option(opts)
   endif
@@ -97,56 +97,92 @@ function! s:nomalize_rel(rel) abort
   return rel
 endfunction
 
-function! s:make_sink(root_path, common_sink) abort
+function! s:make_sink(root_path, common_sink, helper) abort
   function! s:sink(lines) abort closure
-    if len(a:lines) < 2
-      return
-    endif
-    let key = remove(a:lines, 0)
-    let rel_paths = a:lines
-    call map(rel_paths, {->s:nomalize_rel(v:val)})
-    let ex_dir_sink = exists("*g:Fern_mapping_fzf_dir_sink") || type(get(g:, "Fern_mapping_fzf_dir_sink")) == v:t_func
-    let ex_file_sink = exists("*g:Fern_mapping_fzf_file_sink") || type(get(g:, "Fern_mapping_fzf_file_sink")) == v:t_func
+    function! s:sink_main(...) abort closure
+      if len(a:lines) < 2
+        return s:Promise.resolve()
+      endif
+      let rel_paths = copy(a:lines)
+      let key = remove(rel_paths, 0)
+      call map(rel_paths, {->s:nomalize_rel(v:val)})
+      let ex_dir_sink = exists("*g:Fern_mapping_fzf_dir_sink") || type(get(g:, "Fern_mapping_fzf_dir_sink")) == v:t_func
+      let ex_file_sink = exists("*g:Fern_mapping_fzf_file_sink") || type(get(g:, "Fern_mapping_fzf_file_sink")) == v:t_func
 
-    if !ex_dir_sink && !ex_file_sink
-      let full_paths = copy(rel_paths)
-      call map(full_paths, {->s:F.join(a:root_path, v:val)})
-      call a:common_sink([key] + full_paths)
-    else
-      let dir_paths = [key]
-      let file_paths = [key]
-      for relative_path in rel_paths
-        let full_path = s:F.join(a:root_path, relative_path)
-        let dict = {
-              \   'key': key,
-              \   'root_path': a:root_path,
-              \   'full_path': full_path,
-              \   'relative_path': relative_path,
-              \ }
-        if isdirectory(full_path)
-          if ex_dir_sink
-            let dict.is_dir = v:true
-            call g:Fern_mapping_fzf_dir_sink(dict)
-          else
-            let dir_paths += [full_path]
+      if !ex_dir_sink && !ex_file_sink
+        let full_paths = copy(rel_paths)
+        call map(full_paths, {->s:F.join(a:root_path, v:val)})
+        call a:common_sink([key] + full_paths)
+      else
+        let dir_paths = [key]
+        let file_paths = [key]
+        for relative_path in rel_paths
+          let full_path = s:F.join(a:root_path, relative_path)
+          let dict = {
+                \   'key': key,
+                \   'lines': a:lines,
+                \   'fern_helper': a:helper,
+                \   'root_path': a:root_path,
+                \   'full_path': full_path,
+                \   'relative_path': relative_path,
+                \ }
+          if isdirectory(full_path)
+            if ex_dir_sink
+              let dict.is_dir = v:true
+              call g:Fern_mapping_fzf_dir_sink(dict)
+            else
+              let dir_paths += [full_path]
+            endif
+          elseif filereadable(full_path)
+            if ex_file_sink
+              let dict.is_dir = v:false
+              call g:Fern_mapping_fzf_file_sink(dict)
+            else
+              let file_paths += [full_path]
+            endif
           endif
-        elseif filereadable(full_path)
-          if ex_file_sink
-            let dict.is_dir = v:false
-            call g:Fern_mapping_fzf_file_sink(dict)
-          else
-            let file_paths += [full_path]
-          endif
+        endfor
+        if !ex_dir_sink
+          call a:common_sink(dir_paths)
         endif
-      endfor
-      if !ex_dir_sink
-        call a:common_sink(dir_paths)
+        if !ex_file_sink
+          call a:common_sink(file_paths)
+        endif
       endif
-      if !ex_file_sink
-        call a:common_sink(file_paths)
+      return s:Promise.resolve()
+    endfunction
+
+    function! s:sink_before_all(...) abort closure
+      let dict = {
+          \   'lines': copy(a:lines),
+          \   'fern_helper': a:helper,
+          \   'root_path': a:root_path,
+          \ }
+      let ex_before_all = exists("*g:Fern_mapping_fzf_before_all") || type(get(g:, "Fern_mapping_fzf_before_all")) == v:t_func
+      if ex_before_all
+        return s:Promise.resolve(g:Fern_mapping_fzf_before_all(dict))
       endif
-    endif
+      return s:Promise.resolve()
+    endfunction
+
+    function! s:sink_after_all(...) abort closure
+      let dict = {
+          \   'lines': copy(a:lines),
+          \   'fern_helper': a:helper,
+          \   'root_path': a:root_path,
+          \ }
+      let ex_after_all = exists("*g:Fern_mapping_fzf_after_all") || type(get(g:, "Fern_mapping_fzf_after_all")) == v:t_func
+      if ex_after_all
+        return s:Promise.resolve(g:Fern_mapping_fzf_after_all(dict))
+      endif
+      return s:Promise.resolve()
+    endfunction
+
+    call s:sink_before_all()
+      \.then(funcref('s:sink_main'))
+      \.then(funcref('s:sink_after_all'))
   endfunction
+
   return function('s:sink')
 endfunction
 
@@ -158,6 +194,8 @@ function! s:escape(str) abort
 endfunction
 
 let g:fern#mapping#fzf#disable_default_mappings = get(g:, 'fern#mapping#fzf#disable_default_mappings', 0)
+let g:Fern_mapping_fzf_before_all = get(g:, 'Fern_mapping_fzf_before_all', 0)
+let g:Fern_mapping_fzf_after_all = get(g:, 'Fern_mapping_fzf_after_all', 0)
 let g:Fern_mapping_fzf_customize_option = get(g:, 'Fern_mapping_fzf_customize_option', 0)
 let g:Fern_mapping_fzf_dir_sink = get(g:, 'Fern_mapping_fzf_dir_sink', 0)
 let g:Fern_mapping_fzf_file_sink = get(g:, 'Fern_mapping_fzf_file_sink', 0)

--- a/doc/fern-mapping-fzf.txt
+++ b/doc/fern-mapping-fzf.txt
@@ -60,6 +60,7 @@ OPTIONS 				*fern-mapping-fzf-options*
 	  {dict}.is_dir		: |v:false|
 	  {dict}.root_path	: Path original fern executed.
 	  {dict}.fern_helper	: Fern helper dict. |fern-develop-helper|
+	  {dict}.lines		: Lines got from fzf.
 	Be careful you cannot return Promise for now.
 	Default: Respects fzf default behavior. See |g:fzf_action|.
 Example: >
@@ -80,6 +81,7 @@ Example: >
 	  {dict}.is_dir		: |v:true|
 	  {dict}.root_path	: Path original fern executed.
 	  {dict}.fern_helper	: Fern helper dict. |fern-develop-helper|
+	  {dict}.lines		: Lines got from fzf.
 	Be careful you cannot return Promise for now.
 	Default: Respects fzf default behavior. See |g:fzf_action|.
 
@@ -96,9 +98,13 @@ Example: >
 <
 
 *g:Fern_mapping_fzf_before_all*
-	Set funcref that accepts one {spec-dict} argument. It can return
+	Set funcref that accepts one {dict} argument. It can return
 	Promise. It will be run before all running sink functions, but after
 	fzf finishing.
+	  {dict}.key		: The key used to finish fzf. e.g. `ctrl-v`
+	  {dict}.root_path	: Path original fern executed.
+	  {dict}.fern_helper	: Fern helper dict. |fern-develop-helper|
+	  {dict}.lines		: Lines got from fzf.
 	Default: Do nothing.
 Example: >
 	function! Fern_mapping_fzf_before_all(dict)
@@ -107,8 +113,12 @@ Example: >
 <
 
 *g:Fern_mapping_fzf_after_all*
-	Set funcref that accepts one {spec-dict} argument. It can return
+	Set funcref that accepts one {dict} argument. It can return
 	Promise. It will be run after all running sink functions.
+	  {dict}.key		: The key used to finish fzf. e.g. `ctrl-v`
+	  {dict}.root_path	: Path original fern executed.
+	  {dict}.fern_helper	: Fern helper dict. |fern-develop-helper|
+	  {dict}.lines		: Lines got from fzf.
 	Default: Do nothing.
 Example: >
 	function! s:reveal(dict)

--- a/doc/fern-mapping-fzf.txt
+++ b/doc/fern-mapping-fzf.txt
@@ -59,7 +59,7 @@ OPTIONS 				*fern-mapping-fzf-options*
 				  file. Useful for |:FernReveal|.
 	  {dict}.is_dir		: |v:false|
 	  {dict}.root_path	: Path original fern executed.
-	Note: Censoring the drawer mode is not supported now, sorry.
+	  {dict}.fern_helper	: Fern helper dict. |fern-develop-helper|
 	Default: Respects fzf default behavior. See |g:fzf_action|.
 Example: >
 	" Recipe for :FernReveal
@@ -78,6 +78,7 @@ Example: >
 				  directory. Useful for |:FernReveal|.
 	  {dict}.is_dir		: |v:true|
 	  {dict}.root_path	: Path original fern executed.
+	  {dict}.fern_helper	: Fern helper dict. |fern-develop-helper|
 	Default: Respects fzf default behavior. See |g:fzf_action|.
 
 *g:Fern_mapping_fzf_customize_option*

--- a/doc/fern-mapping-fzf.txt
+++ b/doc/fern-mapping-fzf.txt
@@ -60,6 +60,7 @@ OPTIONS 				*fern-mapping-fzf-options*
 	  {dict}.is_dir		: |v:false|
 	  {dict}.root_path	: Path original fern executed.
 	  {dict}.fern_helper	: Fern helper dict. |fern-develop-helper|
+	Be careful you cannot return Promise for now.
 	Default: Respects fzf default behavior. See |g:fzf_action|.
 Example: >
 	" Recipe for :FernReveal
@@ -79,17 +80,51 @@ Example: >
 	  {dict}.is_dir		: |v:true|
 	  {dict}.root_path	: Path original fern executed.
 	  {dict}.fern_helper	: Fern helper dict. |fern-develop-helper|
+	Be careful you cannot return Promise for now.
 	Default: Respects fzf default behavior. See |g:fzf_action|.
 
 *g:Fern_mapping_fzf_customize_option*
 	Set funcref that accepts one {spec-dict} argument and return dict.
 	This would be passed to |fzf#run|. See |fzf#run| for more information.
+	Default: Do nothing.
 Example: >
 	function! Fern_mapping_fzf_customize_option(spec)
 	    let a:spec.options .= ' --multi'
-	    return a:spec
+	    " Note that fzf#vim#with_preview comes from fzf.vim
+	    return fzf#vim#with_preview(a:spec)
 	endfunction
-  <
+<
+
+*g:Fern_mapping_fzf_before_all*
+	Set funcref that accepts one {spec-dict} argument. It can return
+	Promise. It will be run before all running sink functions, but after
+	fzf finishing.
+	Default: Do nothing.
+Example: >
+	function! Fern_mapping_fzf_before_all(dict)
+	    return a:dict.fern_helper.async.update_marks([])
+	endfunction
+<
+
+*g:Fern_mapping_fzf_after_all*
+	Set funcref that accepts one {spec-dict} argument. It can return
+	Promise. It will be run after all running sink functions.
+	Default: Do nothing.
+Example: >
+	function! s:reveal(dict)
+	    execute "FernReveal -wait" a:dict.relative_path
+	    execute "normal \<Plug>(fern-action-mark:set)"
+	endfunction
+
+	function! Fern_mapping_fzf_after_all(dict)
+	    execute "normal \<Plug>(fern-action-open:vsplit)"
+	endfunction
+
+	let g:Fern_mapping_fzf_file_sink = function('s:reveal')
+	let g:Fern_mapping_fzf_dir_sink = function('s:reveal')
+<
+	NOTE: Disscussions in https://github.com/LumaKernel/fern-mapping-fzf.vim/issues/4
+	also may help.
 
 *g:fern#mapping#fzf#fzf_options*
 	DEPRECATED: Please consider using |g:Fern_mapping_fzf_customize_option| instead.


### PR DESCRIPTION
- `Fern_mapping_fzf_before_all` ( with supporting promise )
- `Fern_mapping_fzf_after_all` ( ditto )
- Passing `fern_helper` to `dict`
- Passing `lines` to `dict`


TODO
- [x] Document them

related: https://github.com/LumaKernel/fern-mapping-fzf.vim/issues/4

also closes https://github.com/LumaKernel/fern-mapping-fzf.vim/issues/2