### PR TITLE
Fix Fern_mapping_fzf_customize_option doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,12 @@ More details, see [`:help fern-mapping-fzf`](https://github.com/LumaKernel/fern-
 ```vim
 function! Fern_mapping_fzf_customize_option(spec)
     let a:spec.options .= ' --multi'
-    return fzf#vim#with_preview(a:spec)
+    " Note that fzf#vim#with_preview comes from fzf.vim
+    if exists('*fzf#vim#with_preview')
+      return fzf#vim#with_preview(a:spec)
+    else
+      return a:spec
+    endif
 endfunction
 
 function! Fern_mapping_fzf_before_all(dict)

--- a/doc/fern-mapping-fzf.txt
+++ b/doc/fern-mapping-fzf.txt
@@ -93,7 +93,11 @@ Example: >
 	function! Fern_mapping_fzf_customize_option(spec)
 	    let a:spec.options .= ' --multi'
 	    " Note that fzf#vim#with_preview comes from fzf.vim
-	    return fzf#vim#with_preview(a:spec)
+	    if exists('*fzf#vim#with_preview')
+	      return fzf#vim#with_preview(a:spec)
+	    else
+	      return a:spec
+	    endif
 	endfunction
 <
 


### PR DESCRIPTION
fzf#vim#with_preview depends on fzf.vim, so we need to modify the doc to check if it exists and then return the configuration.